### PR TITLE
Remove debugging println

### DIFF
--- a/src/clj_pdf_markdown/core.clj
+++ b/src/clj_pdf_markdown/core.clj
@@ -190,8 +190,7 @@
 
 (defmulti render 
   (fn [pdf-config node] 
-    (do (println (str "bean: " (bean node))) 
-        (commonmark-node->class-k node)))
+    (commonmark-node->class-k node))
   :hierarchy render-hierarchy)
 
 (defmethod render :Document [pdf-config node] 


### PR DESCRIPTION
The `render` dispatch method prints some debug information that is useful in development but not necessary in production.

If desired this output could also be put behind a :debug flag in the `pdf-config`.