### PR TITLE
Fix nested lists

### DIFF
--- a/src/clj_pdf_markdown/core.clj
+++ b/src/clj_pdf_markdown/core.clj
@@ -212,15 +212,19 @@
   (.getLiteral node))
 
 (defmethod render :BulletList [pdf-config node]
-  (into [:list (get-in pdf-config [:list :ul])]
-        (render-children* pdf-config node)))
+  [:phrase
+   {}
+   (into [:list (get-in pdf-config [:list :ul])]
+         (apply concat (render-children* pdf-config node)))])
 
-(defmethod render :OrderedList [pdf-config node]  
-  (into [:list (get-in pdf-config [:list :ol])] 
-        (render-children* pdf-config node)))
+(defmethod render :OrderedList [pdf-config node]
+  [:phrase
+   {}
+   (into [:list (get-in pdf-config [:list :ol])]
+         (apply concat (render-children* pdf-config node)))])
 
 (defmethod render :ListItem [pdf-config node]
-  (->> node (render-children* pdf-config) first))
+  (render-children* pdf-config node))
 
 (defmethod render :Link [pdf-config node] 
   (into [:anchor (merge (:anchor pdf-config) {:target (node-destination node)})]

--- a/test/clj_pdf_markdown/core_test.clj
+++ b/test/clj_pdf_markdown/core_test.clj
@@ -63,29 +63,31 @@
             "Text before\n***\nText after"))))
 
   (testing "list"
-    (is (= [:list {:symbol "• "} "List item one" "List item two"]
+    (is (= [:phrase {}
+            [:list {:symbol "• "} "List item one" "List item two"]]
            (markdown->clj-pdf {} "* List item one\n* List item two")))
 
-    (is (= [:list {:numbered true} 
-            "This is the first item" "This is the second item"]
-           (markdown->clj-pdf {} 
+    (is (= [:phrase {}
+            [:list {:numbered true}
+             "This is the first item" "This is the second item"]]
+           (markdown->clj-pdf {}
             "1. This is the first item\n2. This is the second item")))
 
-    (is (= [:list {:symbol "* "} "List item one" "List item two"]
-           (markdown->clj-pdf 
-            {:list {:ul {:symbol "* "}}} 
+    (is (= [:phrase {}
+            [:list {:symbol "* "} "List item one" "List item two"]]
+           (markdown->clj-pdf
+            {:list {:ul {:symbol "* "}}}
             "* List item one\n* List item two")))
 
-    (is (= [:list {:symbol "• "} 
-            [:paragraph {} "List " [:phrase {:style :bold} "styled item"]] 
-            "List regular item"]
-           (markdown->clj-pdf {} 
-            "* List **styled item**\n* List regular item"))))
-
-  (testing "nested lists"
-    (is (->> (markdown->clj-pdf {} "* List item one\n  * List item two (nested)")
-             (tree-seq sequential? #(drop 2 %))
-             (some #{"List item two (nested)"}))))
+    (is (= [:phrase {}
+            [:list {:symbol "• "}
+             [:paragraph {} "List item one"]
+             [:phrase {}
+              [:list {:symbol "• "}
+               "List item two (nested)"]]]]
+           (markdown->clj-pdf
+            {}
+            "* List item one\n  * List item two (nested)"))))
 
   (testing "paragraph"
     (is (= "This is simple text"

--- a/test/clj_pdf_markdown/core_test.clj
+++ b/test/clj_pdf_markdown/core_test.clj
@@ -81,7 +81,12 @@
             "List regular item"]
            (markdown->clj-pdf {} 
             "* List **styled item**\n* List regular item"))))
-  
+
+  (testing "nested lists"
+    (is (->> (markdown->clj-pdf {} "* List item one\n  * List item two (nested)")
+             (tree-seq sequential? #(drop 2 %))
+             (some #{"List item two (nested)"}))))
+
   (testing "paragraph"
     (is (= "This is simple text"
            (markdown->clj-pdf {} "This is simple text")))


### PR DESCRIPTION
Nested lists were being completely discarded.

See 7f4eb7bc6b2d86937fbc7b0763ba0a01c9012f8d for a test demonstrating that the text of the nested node is nowhere to be found in the output.